### PR TITLE
Fix reading leases file when dnsmasq serves IPv6 addresses

### DIFF
--- a/dnsmasq-leases-ui.py
+++ b/dnsmasq-leases-ui.py
@@ -51,11 +51,13 @@ def getLeases():
 	with open(DNSMASQ_LEASES_FILE) as f:
 		for line in f:
 			elements = line.split()
-			entry = LeaseEntry(elements[0],
-					   elements[1],
-					   elements[2],
-					   elements[3])
-			leases.append(entry)
+			if len(elements) == 5:
+				entry = LeaseEntry(elements[0],
+						   elements[1],
+						   elements[2],
+						   elements[3])
+				leases.append(entry)
+
 	leases.sort(key = leaseSort)
 	return jsonify(leases=[lease.serialize() for lease in leases])
 


### PR DESCRIPTION
if dnsmasq serves IPv6 addresses, the lease file contains a single record in form of
duid "the-real-server-duid"
see: http://lists.thekelleys.org.uk/pipermail/dnsmasq-discuss/2016q2/010595.html

the current code did not take this into account and would crash when reading this entry