### PR TITLE
Add feature: click on table header to sort on that element.

### DIFF
--- a/dnsmasq-leases-ui.py
+++ b/dnsmasq-leases-ui.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python
 # This tool provides a web based ui for leases file of the famous DNS/DHCP daemon dnsmasq.
 #
-# 
+#
 # See https://github.com/fschlag/dnsmasq-leases-ui
 # by Florian Schlag (https://github.com/fschlag)
 #
+
 from flask import Flask, render_template, jsonify
 import datetime
+from operator import attrgetter
 
 DNSMASQ_LEASES_FILE = "/var/lib/misc/dnsmasq.leases"
 
@@ -41,12 +43,14 @@ def leaseSort(arg):
 	else:
 		return arg.ipAddress
 
-@app.route("/")
-def index():
-	return render_template('index.html')
+@app.route("/", defaults={'element': 'leasetime'})
+@app.route("/<element>")
+def index(element):
+    return render_template('index.html', element=element)
 
-@app.route("/leases")
-def getLeases():
+@app.route("/leases/", defaults={'element': 'leasetime'})
+@app.route("/leases/<element>")
+def getLeases(element):
 	leases = list()
 	with open(DNSMASQ_LEASES_FILE) as f:
 		for line in f:
@@ -58,7 +62,12 @@ def getLeases():
 						   elements[3])
 				leases.append(entry)
 
-	leases.sort(key = leaseSort)
+	if element=="staticIP":
+        # special case for static(y/n) - sort on staticIP,IP # Fixed IPs first
+		leases.sort(key = leaseSort)
+	else:
+		leases.sort(key=attrgetter( element ))
+
 	return jsonify(leases=[lease.serialize() for lease in leases])
 
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -21,14 +21,18 @@
 	<body>
 	<table id="leases">
 		<tr>
-			<th>IP Address</th><th>Mac Address</th><th>Name</th><th>Static IP?</th><th>Lease ends on</th>
+			<th><a href="ipAddress">IP Address</a></th>
+			<th><a href="macAddress">Mac Address</a></th>
+			<th><a href="name">Name</a></th>
+			<th><a href="staticIP">Static IP</a></th>
+			<th><a href="leasetime">Lease ends on</a></th>
 		</tr>
 	</table>
 	<script src="//ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js" type="text/javascript"></script>
 	<script>
 		$SCRIPT_ROOT = {{ request.script_root|tojson|safe }};
 		$(function() {
-			$.getJSON($SCRIPT_ROOT + '/leases',
+			$.getJSON($SCRIPT_ROOT + '/leases/{{ element }}',
 			function(data) {
 				$('#leases').append(
 					$.map(data.leases, function(ignore, index) {


### PR DESCRIPTION
I generally want to know what IP was just assigned to a box that just booted, so sorting on leasetime.  other times I want other sorts, so this lets us sort on any of the displayed data by clicking on the table header. 